### PR TITLE
fix(travis): use --runInBand flag for travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,7 @@ language: node_js
 node_js:
   - "6"
   - "8"
+script:
+  - npm run test -- --runInBand
 after_success:
   - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js


### PR DESCRIPTION
Closes #5 where [builds were failing on CICD](https://travis-ci.org/americanexpress/parrot/builds/357595523).  Jest test [can be slow on CI servers](https://github.com/facebook/jest/blob/9599d5cce25c24cbbec1aa25152f5e91fd60ba2b/docs/Troubleshooting.md#tests-are-extremely-slow-on-docker-andor-continuous-integration-ci-server), adding the `--runInBand` flag can help speed them up.