### PR TITLE
feat(parrotFetch): mock fetch function passed in through global context object

### DIFF
--- a/packages/parrot-fetch/README.md
+++ b/packages/parrot-fetch/README.md
@@ -17,7 +17,7 @@ const parrot = parrotFetch(scenarios);
 parrot.setActiveScenario('has a ship log');
 ```
 
-## Mocking a non-global fetch
+## Mocking a non-global fetch example
 
 ```js
 import parrotFetch from 'parrot-fetch';
@@ -31,5 +31,22 @@ const fetchWrapper = {
 const parrot = parrotFetch(scenarios, fetchWrapper);
 
 // set the scenario to be used
+parrot.setActiveScenario('has a ship log');
+```
+### Mocking a non-global fetch - use case example
+
+An example use case for mocking a non-global fetch could be mocking a fetchClient that is passed in as an extra thunk argument using [redux-thunk withExtraArgument](https://github.com/reduxjs/redux-thunk). Mocking this redux thunk fetchClient would look something like below:
+
+```js
+import parrotFetch from 'parrot-fetch';
+import scenarios from './scenarios';
+
+const callParrotFetch = () => {
+  return (dispatch, getState, fetchWrapper) => {
+    // fetchWrapper = { fetchClient };
+    return parrotFetch(scenarios, fetchWrapper);
+  };
+};
+const parrot = dispatch(callParrotFetch());
 parrot.setActiveScenario('has a ship log');
 ```

--- a/packages/parrot-fetch/README.md
+++ b/packages/parrot-fetch/README.md
@@ -16,3 +16,20 @@ const parrot = parrotFetch(scenarios);
 // set the scenario to be used
 parrot.setActiveScenario('has a ship log');
 ```
+
+## Mocking a non-global fetch
+
+```js
+import parrotFetch from 'parrot-fetch';
+import scenarios from './scenarios';
+
+// include a fetchClient inside of a fetchWrapper object and pass it into the parrotFetch function to mock the fetchClient
+
+const fetchWrapper = {
+  fetchClient,
+};
+const parrot = parrotFetch(scenarios, fetchWrapper);
+
+// set the scenario to be used
+parrot.setActiveScenario('has a ship log');
+```

--- a/packages/parrot-fetch/__tests__/index.spec.js
+++ b/packages/parrot-fetch/__tests__/index.spec.js
@@ -20,4 +20,11 @@ describe('parrot-fetch', () => {
     parrotFetch();
     expect(fetch).not.toBe(contextFetch);
   });
+  it('should mock fetch in context.thunks object', () => {
+    global.thunks = {
+      fetchClient: fetch,
+    };
+    parrotFetch();
+    expect(fetch).not.toBe(global.thunks.fetchClient);
+  });
 });

--- a/packages/parrot-fetch/__tests__/index.spec.js
+++ b/packages/parrot-fetch/__tests__/index.spec.js
@@ -20,11 +20,19 @@ describe('parrot-fetch', () => {
     parrotFetch();
     expect(fetch).not.toBe(contextFetch);
   });
-  it('should mock fetch in context.thunks object', () => {
-    global.thunks = {
+  it('should mock fetchClient', () => {
+    const fetchWrapper = {
       fetchClient: fetch,
     };
-    parrotFetch();
-    expect(fetch).not.toBe(global.thunks.fetchClient);
+    const scenarios = {
+      one: [
+        {
+          request: () => 'test',
+          response: () => 'response',
+        },
+      ],
+    };
+    parrotFetch(scenarios, fetchWrapper);
+    expect(fetch).not.toBe(fetchWrapper.fetchClient);
   });
 });

--- a/packages/parrot-fetch/src/index.js
+++ b/packages/parrot-fetch/src/index.js
@@ -15,12 +15,14 @@
 import ParrotFetch from './ParrotFetch';
 
 /* istanbul ignore next */
-const context = typeof global === 'undefined' ? self : global; // eslint-disable-line no-restricted-globals
-const contextFetch = context.fetch.bind(context);
+const globalContext = typeof global === 'undefined' ? self : global; // eslint-disable-line no-restricted-globals
+const contextFetch = globalContext.fetch.bind(globalContext);
 export const PARROT_STATE = 'PARROT_STATE';
 
-export default function init(scenarios) {
+export default function init(scenarios, contextParam = globalContext) {
+  const context = contextParam;
   let parrotFetch;
+  // Option to mock a fetch client in a redux thunk object by attaching it to the context
   if (context.thunks) {
     parrotFetch = new ParrotFetch(scenarios, context.thunks.fetchClient);
     context.thunks.fetchClient = parrotFetch.resolve;

--- a/packages/parrot-fetch/src/index.js
+++ b/packages/parrot-fetch/src/index.js
@@ -15,17 +15,17 @@
 import ParrotFetch from './ParrotFetch';
 
 /* istanbul ignore next */
-const globalContext = typeof global === 'undefined' ? self : global; // eslint-disable-line no-restricted-globals
-const contextFetch = globalContext.fetch.bind(globalContext);
+const context = typeof global === 'undefined' ? self : global; // eslint-disable-line no-restricted-globals
+const contextFetch = context.fetch.bind(context);
 export const PARROT_STATE = 'PARROT_STATE';
 
-export default function init(scenarios, contextParam = globalContext) {
-  const context = contextParam;
+export default function init(scenarios, fetchWrapperParam) {
+  const fetchWrapper = fetchWrapperParam;
   let parrotFetch;
-  // Option to mock a fetch client in a redux thunk object by attaching it to the context
-  if (context.thunks) {
-    parrotFetch = new ParrotFetch(scenarios, context.thunks.fetchClient);
-    context.thunks.fetchClient = parrotFetch.resolve;
+  // option to mock a fetchClient that is different from the global fetch by passing the fetchClient in through a fetchWrapper object.
+  if (fetchWrapper) {
+    parrotFetch = new ParrotFetch(scenarios, fetchWrapper.fetchClient);
+    fetchWrapper.fetchClient = parrotFetch.resolve;
   } else {
     parrotFetch = new ParrotFetch(scenarios, contextFetch);
     context.fetch = parrotFetch.resolve;

--- a/packages/parrot-fetch/src/index.js
+++ b/packages/parrot-fetch/src/index.js
@@ -20,7 +20,13 @@ const contextFetch = context.fetch.bind(context);
 export const PARROT_STATE = 'PARROT_STATE';
 
 export default function init(scenarios) {
-  const parrotFetch = new ParrotFetch(scenarios, contextFetch);
-  context.fetch = parrotFetch.resolve;
+  let parrotFetch;
+  if (context.thunks) {
+    parrotFetch = new ParrotFetch(scenarios, context.thunks.fetchClient);
+    context.thunks.fetchClient = parrotFetch.resolve;
+  } else {
+    parrotFetch = new ParrotFetch(scenarios, contextFetch);
+    context.fetch = parrotFetch.resolve;
+  }
   return parrotFetch;
 }


### PR DESCRIPTION
iguazu-rest and iguazu-resources use a fetchClient that lives inside the redux thunks object.

this fetchClient is initialized from the global fetch, but it is a different fetch than the global fetch. so the current parrot-fetch does not mock this fetchClient.

passing in this fetchClient in order to mock it with parrot-fetch.