### PR TITLE
fix(parrot-devtools) use firefox compatible paths for assets

### DIFF
--- a/packages/parrot-devtools/__tests__/browser/extension/devtools.spec.js
+++ b/packages/parrot-devtools/__tests__/browser/extension/devtools.spec.js
@@ -26,8 +26,8 @@ describe('devtools', () => {
   it('should setup tab', () => {
     expect(global.chrome.devtools.panels.create).toHaveBeenCalledWith(
       'Parrot',
-      'assets/img/parrot_48x.png',
-      'views/devtool-panel.html'
+      '/assets/img/parrot_48x.png',
+      '/views/devtool-panel.html'
     );
   });
 });

--- a/packages/parrot-devtools/src/browser/extension/devtools.js
+++ b/packages/parrot-devtools/src/browser/extension/devtools.js
@@ -13,4 +13,4 @@
  */
 
 // create our devtool tab/panel in the devtools
-chrome.devtools.panels.create('Parrot', 'assets/img/parrot_48x.png', 'views/devtool-panel.html');
+chrome.devtools.panels.create('Parrot', '/assets/img/parrot_48x.png', '/views/devtool-panel.html');


### PR DESCRIPTION
Pass absolute asset path references to `devtools.panels.create` so that Mozilla can resolve them.

[MDN docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/devtools.panels/create)