### PR TITLE
chore(packages): add repository directory to package

### DIFF
--- a/packages/parrot-core/package.json
+++ b/packages/parrot-core/package.json
@@ -12,7 +12,11 @@
   ],
   "main": "lib",
   "license": "Apache-2.0",
-  "repository": "americanexpress/parrot",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/americanexpress/parrot.git",
+    "directory": "packages/parrot-core"
+  },
   "scripts": {
     "clean": "rimraf lib",
     "prebuild": "npm run clean",

--- a/packages/parrot-devtools/package.json
+++ b/packages/parrot-devtools/package.json
@@ -20,7 +20,11 @@
     "deploy:extension": "node scripts/deploy-to-webstore.js"
   },
   "license": "Apache-2.0",
-  "repository": "americanexpress/parrot",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/americanexpress/parrot.git",
+    "directory": "packages/parrot-devtools"
+  },
   "dependencies": {
     "prop-types": "^15.8.1",
     "react": "^16.14.0",

--- a/packages/parrot-fetch/package.json
+++ b/packages/parrot-fetch/package.json
@@ -12,7 +12,11 @@
   ],
   "main": "lib",
   "license": "Apache-2.0",
-  "repository": "americanexpress/parrot",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/americanexpress/parrot.git",
+    "directory": "packages/parrot-fetch"
+  },
   "scripts": {
     "clean": "rimraf lib",
     "prebuild": "npm run clean",

--- a/packages/parrot-friendly/package.json
+++ b/packages/parrot-friendly/package.json
@@ -12,7 +12,11 @@
   ],
   "main": "lib",
   "license": "Apache-2.0",
-  "repository": "americanexpress/parrot",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/americanexpress/parrot.git",
+    "directory": "packages/parrot-friendly"
+  },
   "scripts": {
     "clean": "rimraf lib",
     "prebuild": "npm run clean",

--- a/packages/parrot-graphql/package.json
+++ b/packages/parrot-graphql/package.json
@@ -9,7 +9,11 @@
   "description": "A helper library to create GraphQL Parrot mocks.",
   "main": "src/index.js",
   "license": "Apache-2.0",
-  "repository": "americanexpress/parrot",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/americanexpress/parrot.git",
+    "directory": "packages/parrot-graphql"
+  },
   "dependencies": {
     "@graphql-tools/mock": "^8.7.20",
     "graphql": "^15.8.0"

--- a/packages/parrot-middleware/package.json
+++ b/packages/parrot-middleware/package.json
@@ -12,7 +12,11 @@
   ],
   "main": "lib",
   "license": "Apache-2.0",
-  "repository": "americanexpress/parrot",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/americanexpress/parrot.git",
+    "directory": "packages/parrot-middleware"
+  },
   "scripts": {
     "clean": "rimraf lib",
     "prebuild": "npm run clean",

--- a/packages/parrot-server/package.json
+++ b/packages/parrot-server/package.json
@@ -12,7 +12,11 @@
     "lib"
   ],
   "license": "Apache-2.0",
-  "repository": "americanexpress/parrot",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/americanexpress/parrot.git",
+    "directory": "packages/parrot-server"
+  },
   "bin": {
     "parrot-server": "./lib/index.js"
   },


### PR DESCRIPTION
## Description
Set the repository fields properly for the packages, including directory names.

## Motivation and Context
I noticed the header image here is a 404: https://www.npmjs.com/package/parrot-friendly

This is because npmjs.com is taking the relative URL for the image specified in the README.md and applying it to the root GitHub repo, which is not where that file exists since it's a monorepo.

I **suspect** that adding the directory here will fix the issue. At the very least it is more correct.

## How Has This Been Tested?
Not tested. package.json config only.

Verified that other popular monorepos have this same configuration:
https://github.com/babel/babel/blob/main/packages/babel-compat-data/package.json
https://github.com/jestjs/jest/blob/main/packages/create-jest/package.json

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using parrot?
Hopefully better display on npmjs.com.