### PR TITLE
feat(parrot): override active parrot scenario with cookie

### DIFF
--- a/packages/parrot-core/package.json
+++ b/packages/parrot-core/package.json
@@ -35,6 +35,7 @@
     "@babel/core": "^7.22.10",
     "@babel/plugin-transform-runtime": "^7.22.10",
     "babel-preset-amex": "^3.6.1",
+    "jest-when": "^3.6.0",
     "rimraf": "^3.0.2"
   }
 }

--- a/packages/parrot-core/src/Parrot.js
+++ b/packages/parrot-core/src/Parrot.js
@@ -54,7 +54,9 @@ class Parrot {
   resolve = async (...platformRequest) => {
     const normalizedRequest = this.normalizeRequest(...platformRequest);
     const resolver = this.resolver(...platformRequest);
-    const mocks = this.scenarios[this.activeScenario];
+    const activeScenarioOverride =
+      this.getActiveScenarioOverride && this.getActiveScenarioOverride(...platformRequest);
+    const mocks = this.scenarios[activeScenarioOverride || this.activeScenario];
     const mock = await matchMock(normalizedRequest, platformRequest, mocks);
     return resolveResponse(normalizedRequest, platformRequest, mock, resolver);
   };

--- a/packages/parrot-middleware/__tests__/ParrotMiddleware.spec.js
+++ b/packages/parrot-middleware/__tests__/ParrotMiddleware.spec.js
@@ -16,7 +16,7 @@ import ParrotMiddleware from '../src/ParrotMiddleware';
 
 jest.mock('parrot-core', () => class {});
 
-describe('ParrotFetch', () => {
+describe('ParrotMiddleware', () => {
   it('should normalize', () => {
     const parrotFetch = new ParrotMiddleware();
     const normalized = parrotFetch.normalizeRequest({
@@ -84,5 +84,30 @@ describe('ParrotFetch', () => {
     parrotMiddleware.resolver(req, res, next)(response);
     expect(res.type).toHaveBeenCalled();
     expect(res.send).toHaveBeenCalled();
+  });
+
+  it('should return the active scenario override from the cookie', () => {
+    const testScenarioName = 'Test Scenario Name';
+    const req = {
+      cookies: {
+        parrotScenarioOverride: testScenarioName,
+      },
+    };
+    const parrotMiddleware = new ParrotMiddleware();
+    expect(parrotMiddleware.getActiveScenarioOverride(req)).toEqual(testScenarioName);
+  });
+
+  it('should return undefined if the active scenario override is not present as a cookie', () => {
+    const req = {
+      cookies: {},
+    };
+    const parrotMiddleware = new ParrotMiddleware();
+    expect(parrotMiddleware.getActiveScenarioOverride(req)).toBeUndefined();
+  });
+
+  it('should return undefined if there are no cookies', () => {
+    const req = {};
+    const parrotMiddleware = new ParrotMiddleware();
+    expect(parrotMiddleware.getActiveScenarioOverride(req)).toBeUndefined();
   });
 });

--- a/packages/parrot-middleware/package.json
+++ b/packages/parrot-middleware/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "body-parser": "^1.20.2",
+    "cookie-parser": "^1.4.7",
     "express": "^4.18.2",
     "parrot-core": "^5.1.0"
   },

--- a/packages/parrot-middleware/src/ParrotMiddleware.js
+++ b/packages/parrot-middleware/src/ParrotMiddleware.js
@@ -41,6 +41,8 @@ class ParrotMiddleware extends Parrot {
       res.send(body);
     }
   };
+
+  getActiveScenarioOverride = req => (req.cookies ? req.cookies.parrotScenarioOverride : undefined);
 }
 
 export default ParrotMiddleware;

--- a/packages/parrot-middleware/src/index.js
+++ b/packages/parrot-middleware/src/index.js
@@ -14,6 +14,7 @@
 
 import { Router } from 'express';
 import bodyParser from 'body-parser';
+import cookieParser from 'cookie-parser';
 import ParrotMiddleware from './ParrotMiddleware';
 
 export default function parrot(scenarios) {
@@ -35,5 +36,5 @@ export default function parrot(scenarios) {
     res.json(parrotMiddleware.getScenarios());
   });
 
-  return [jsonParser, parrotRouter, parrotMiddleware.resolve];
+  return [jsonParser, cookieParser(), parrotRouter, parrotMiddleware.resolve];
 }


### PR DESCRIPTION
Change to parrot-core. When resolving a request, use an optional method which will look for a parrot scenario name in the request cookie and use this to determine which set of mocks to use instead of using the active scenario

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] My changes are in sync with the code style of this project.
- [ ] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using parrot?
<!--- Please describe how your changes impacts developers using parrot. -->
