### PR TITLE
fix(matchMock): handle regex mock paths directly

### DIFF
--- a/packages/parrot-core/__tests__/utils/matchMock.spec.js
+++ b/packages/parrot-core/__tests__/utils/matchMock.spec.js
@@ -49,6 +49,22 @@ describe('matchMock', () => {
     expect(matchMock(req, {}, mocks)).toEqual(mocks[0]);
   });
 
+  it('matches mock object when path variable', () => {
+    const mocks = [
+      { request: { path: '/squawk/:id', headers: 'ahoy', 'Keep-Alive': 'timeout=5' } },
+    ];
+    const req = { path: '/squawk/123', headers: 'ahoy', 'Keep-Alive': 'timeout=5' };
+    expect(matchMock(req, {}, mocks)).toEqual(mocks[0]);
+  });
+
+  it('matches mock object when regex path', () => {
+    const mocks = [
+      { request: { path: /^\/squawk\/\d?/, headers: 'ahoy', 'Keep-Alive': 'timeout=5' } },
+    ];
+    const req = { path: '/squawk/123', headers: 'ahoy', 'Keep-Alive': 'timeout=5' };
+    expect(matchMock(req, {}, mocks)).toEqual(mocks[0]);
+  });
+
   it('throws when mocks is not an array', () => {
     const mocks = {};
     expect(() => matchMock({}, {}, mocks)).toThrow(

--- a/packages/parrot-core/src/utils/matchMock.js
+++ b/packages/parrot-core/src/utils/matchMock.js
@@ -21,6 +21,9 @@ function matchRequest(normalizedRequest) {
   return request =>
     Object.keys(request).every(property => {
       if (property === 'path') {
+        if (request.path instanceof RegExp) {
+          return request.path.test(normalizedRequest.path);
+        }
         const matchRoute = match(request.path);
         const result = matchRoute(normalizedRequest.path);
         return result !== false;


### PR DESCRIPTION
## Description
Handle regex paths directly rather than passing them to path-to-regexp.

## Motivation and Context
#269 upgraded path-to-regexp to v8 from v3.  An error was reported when using a regexp for the path variable with that change.

Scenario:
```
const scenarios = {
  test: [
    {
      request: {
        method: 'GET',
        path: /^\/api\/v1\/metadata\/variables\/draft\/\w+$/,
      },
      response: {},
    },
  ],
};
```

Error after doing any GET call to the parrot mock:
```
FATAL: str is not iterable
    reason: "unhandledRejection"
    error: {
      "type": "TypeError",
      "message": "str is not iterable",
      "stack":
          TypeError: str is not iterable
              at lexer (/opt/module-workspace/foo/node_modules/parrot-core/node_modules/path-to-regexp/dist/index.js:43:23)
              at lexer.next (<anonymous>)
```

Looking at the path-to-regexp README shows a missed signature change:

v3 README:
```
path A string, array of strings, or a regular expression.
```

v8 README:
```
path String or array of strings.
```

I'm not 100% clear on why passing in a regex is failing, and it still seems to work in unit tests. But it seems wise to not do it since it's undocumented.  We can just check for a regex path directly and evaluate it without path-to-regexp at all.

## How Has This Been Tested?

Added new unit tests.  Verified this fixes issue in cited example.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [ ] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using parrot?
Fixes issue with regexp paths.
