### PR TITLE
feat(middleware): log unhandled requests

### DIFF
--- a/packages/parrot-core/__tests__/Parrot.spec.js
+++ b/packages/parrot-core/__tests__/Parrot.spec.js
@@ -35,9 +35,10 @@ class ParrotTest extends Parrot {
 
 describe('Parrot', () => {
   it('normalizes scenarios and sets logger', () => {
-    new ParrotTest(); // eslint-disable-line no-new
+    const parrotTest = new ParrotTest();
     expect(normalizeScenarios).toHaveBeenCalledWith({});
     expect(logger.setScenario).toHaveBeenCalledWith(undefined);
+    expect(parrotTest.logger).toBe(logger);
   });
 
   it('should get the active scenario name', () => {

--- a/packages/parrot-core/src/Parrot.js
+++ b/packages/parrot-core/src/Parrot.js
@@ -19,6 +19,7 @@ class Parrot {
     this.scenarios = normalizeScenarios(scenarios);
     [this.activeScenario] = Object.keys(scenarios);
     logger.setScenario(this.activeScenario);
+    this.logger = logger;
   }
 
   getActiveScenario = () => this.activeScenario;

--- a/packages/parrot-middleware/__tests__/ParrotMiddleware.spec.js
+++ b/packages/parrot-middleware/__tests__/ParrotMiddleware.spec.js
@@ -14,7 +14,15 @@
 
 import ParrotMiddleware from '../src/ParrotMiddleware';
 
-jest.mock('parrot-core', () => class {});
+jest.mock(
+  'parrot-core',
+  () =>
+    class {
+      constructor() {
+        this.logger = { warn: jest.fn() };
+      }
+    }
+);
 
 describe('ParrotMiddleware', () => {
   it('should normalize', () => {
@@ -27,13 +35,17 @@ describe('ParrotMiddleware', () => {
     });
   });
 
-  it('should call next middleware', () => {
+  it('should call next middleware and log a warning', () => {
     const req = {};
     const res = { headersSent: false };
     const next = jest.fn();
     const parrotMiddleware = new ParrotMiddleware();
     parrotMiddleware.resolver(req, res, next)();
     expect(next).toHaveBeenCalled();
+    expect(parrotMiddleware.logger.warn).toHaveBeenCalledWith(
+      'No matching mock found for request',
+      req.path
+    );
   });
 
   it('should not call next middleware if headers sent', () => {

--- a/packages/parrot-middleware/src/ParrotMiddleware.js
+++ b/packages/parrot-middleware/src/ParrotMiddleware.js
@@ -22,6 +22,7 @@ class ParrotMiddleware extends Parrot {
       return;
     }
     if (!response) {
+      this.logger.warn('No matching mock found for request', req.path);
       next();
       return;
     }


### PR DESCRIPTION
## Description

Add a log line to parrot-middleware when a response is not handled.

<img width="1142" alt="Screenshot 2024-11-27 at 3 24 41 PM" src="https://github.com/user-attachments/assets/731c13d7-d081-43f6-b6d4-ef3754d01015">


This also exposes the `logger` on the `Parrot` object so it can be used by `ParrotMiddleware` for consistent log styling.

## Motivation and Context

Currently parrot only logs when a request is matched.  This is great when everything is working but there are times when it is good to see the unhandled requests.

Questions I'm not sure of:
* Are there use cases where people are expecting a ton of misses and the logs would be junk?
* Are there use cases where parrot-middleware adding a log line would be confusing?
* Would it be helpful to log more of the unmatched request, or would it be too much noise?
* Should this be configurable? And opt-in or opt-out?

## How Has This Been Tested?
Packed and ran with a local React module. Added unit tests.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using parrot?

Mock misses will be much easier to see, especially when the call is server-side rather than browser.