### PR TITLE
feat(parrot-friendly): make parrot-graphql an optional peer dep

### DIFF
--- a/packages/parrot-friendly/package-lock.json
+++ b/packages/parrot-friendly/package-lock.json
@@ -6,16 +6,22 @@
   "packages": {
     "": {
       "name": "parrot-friendly",
-      "version": "5.0.0",
+      "version": "5.3.0",
       "license": "Apache-2.0",
-      "dependencies": {
-        "parrot-graphql": "^5.0.0"
-      },
       "devDependencies": {
         "@babel/cli": "^7.22.10",
         "@babel/core": "^7.22.10",
         "babel-preset-amex": "^3.6.1",
+        "parrot-graphql": "^5.3.0",
         "rimraf": "^3.0.2"
+      },
+      "peerDependencies": {
+        "parrot-graphql": "^5.3.0"
+      },
+      "peerDependenciesMeta": {
+        "parrot-graphql": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1866,6 +1872,7 @@
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-8.4.2.tgz",
       "integrity": "sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw==",
+      "dev": true,
       "dependencies": {
         "@graphql-tools/utils": "^9.2.1",
         "tslib": "^2.4.0"
@@ -1878,6 +1885,7 @@
       "version": "8.7.20",
       "resolved": "https://registry.npmjs.org/@graphql-tools/mock/-/mock-8.7.20.tgz",
       "integrity": "sha512-ljcHSJWjC/ZyzpXd5cfNhPI7YljRVvabKHPzKjEs5ElxWu2cdlLGvyNYepApXDsM/OJG/2xuhGM+9GWu5gEAPQ==",
+      "dev": true,
       "dependencies": {
         "@graphql-tools/schema": "^9.0.18",
         "@graphql-tools/utils": "^9.2.1",
@@ -1892,6 +1900,7 @@
       "version": "9.0.19",
       "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-9.0.19.tgz",
       "integrity": "sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w==",
+      "dev": true,
       "dependencies": {
         "@graphql-tools/merge": "^8.4.1",
         "@graphql-tools/utils": "^9.2.1",
@@ -1906,6 +1915,7 @@
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-9.2.1.tgz",
       "integrity": "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==",
+      "dev": true,
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "tslib": "^2.4.0"
@@ -1918,6 +1928,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
       "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "dev": true,
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
@@ -2091,13 +2102,14 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2136,9 +2148,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001520",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001520.tgz",
-      "integrity": "sha512-tahF5O9EiiTzwTUqAeFjIZbn4Dnqxzz7ktrgGlMYNLH43Ul26IgTMH/zvL3DG0lZxBYnlT04axvInszUsZULdA==",
+      "version": "1.0.30001692",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001692.tgz",
+      "integrity": "sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==",
       "dev": true,
       "funding": [
         {
@@ -2153,7 +2165,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "2.4.2",
@@ -2299,13 +2312,15 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -2401,6 +2416,7 @@
       "version": "15.8.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
       "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
+      "dev": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -2495,6 +2511,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.12.0"
@@ -2611,9 +2628,11 @@
       }
     },
     "node_modules/parrot-graphql": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/parrot-graphql/-/parrot-graphql-5.0.0.tgz",
-      "integrity": "sha512-if9d/9jgFKrvBgY7fJfl3EgttcRINBC2mOTNCi5r8WPqUn8NaAX+AiL+g9VYwSyp7H1Q8VQ6u5poqWappCGfSA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/parrot-graphql/-/parrot-graphql-5.3.0.tgz",
+      "integrity": "sha512-MQhVpPzWU9tUvvVlrxu0d7VLF+v/u1SwluzC0un2Wod9JZ9m+XVW8iQtdY6NFRl8a5le4YBWpLHHxn1wLcJ9vg==",
+      "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@graphql-tools/mock": "^8.7.20",
         "graphql": "^15.8.0"
@@ -2834,6 +2853,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "is-number": "^7.0.0"
@@ -2845,7 +2865,8 @@
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+      "dev": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -2921,6 +2942,7 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/value-or-promise/-/value-or-promise-1.0.12.tgz",
       "integrity": "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }

--- a/packages/parrot-friendly/package.json
+++ b/packages/parrot-friendly/package.json
@@ -23,13 +23,19 @@
     "build": "babel src --out-dir lib --copy-files",
     "prepublish": "npm run build"
   },
-  "dependencies": {
+  "peerDependencies": {
     "parrot-graphql": "^5.3.0"
+  },
+  "peerDependenciesMeta": {
+    "parrot-graphql": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@babel/cli": "^7.22.10",
     "@babel/core": "^7.22.10",
     "babel-preset-amex": "^3.6.1",
+    "parrot-graphql": "^5.3.0",
     "rimraf": "^3.0.2"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Move `parrot-graphql` to be an optional peer dep of `parrot-friendly`.

## Motivation and Context

`parrot-graphql` is the only dependency of `parrot-friendly` and adds a lot of dependencies.   If you don't use the graphql support, this is a bit of a waste.

```
├─┬ parrot-friendly@4.1.1
│ └─┬ parrot-graphql@4.1.1
│   ├─┬ graphql-tools@2.24.0
│   │ ├─┬ apollo-link@1.2.14
│   │ │ ├── apollo-utilities@1.3.4 deduped
│   │ │ ├── graphql@0.11.7 deduped
│   │ │ ├─┬ ts-invariant@0.4.4
│   │ │ │ └── tslib@1.14.1
│   │ │ ├── tslib@1.14.1
│   │ │ └─┬ zen-observable-ts@0.8.21
│   │ │   ├── tslib@1.14.1
│   │ │   └── zen-observable@0.8.15
│   │ ├─┬ apollo-utilities@1.3.4
│   │ │ ├─┬ @wry/equality@0.1.11
│   │ │ │ └── tslib@1.14.1
│   │ │ ├── fast-json-stable-stringify@2.1.0 deduped
│   │ │ ├── graphql@0.11.7 deduped
│   │ │ ├── ts-invariant@0.4.4 deduped
│   │ │ └── tslib@1.14.1
│   │ ├── deprecated-decorator@0.1.6
│   │ ├── graphql@0.11.7 deduped
│   │ ├── iterall@1.1.3
│   │ └── uuid@3.4.0
│   └─┬ graphql@0.11.7
│     └── iterall@1.1.3 deduped
```

**Is this a breaking change?**

## How Has This Been Tested?
Packed and installed parrot-friendly and verified that the graphql deps no longer are listed, and that parrot-friendly still works as expected.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update
